### PR TITLE
update gke

### DIFF
--- a/modules/gcp/gke/main.tf
+++ b/modules/gcp/gke/main.tf
@@ -50,8 +50,6 @@ resource "google_container_cluster" "gke-cluster" {
     client_certificate_config {
       issue_client_certificate = false
     }
-    username = ""
-    password = ""
   }
 
   master_authorized_networks_config {
@@ -79,7 +77,7 @@ resource "google_container_cluster" "gke-cluster" {
   remove_default_node_pool = true
 
   workload_identity_config {
-    identity_namespace = "${var.project}.svc.id.goog"
+    workload_pool = "${var.project}.svc.id.goog"
   }
 }
 


### PR DESCRIPTION
Task: https://app.asana.com/0/1201752705032002/1201545328168376
Errors fixed:
```
│ required_providers block.
╵
╷
│ Error: Unsupported argument
│ 
│ on .terraform/modules/gke/modules/gcp/gke/main.tf line 54, in resource "google_container_cluster" "gke-cluster":
│ 54: username = ""
│ 
│ An argument named "username" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│ on .terraform/modules/gke/modules/gcp/gke/main.tf line 55, in resource "google_container_cluster" "gke-cluster":
│ 55: password = ""
│ 
│ An argument named "password" is not expected here.
╵
╷
│ Error: Unsupported argument
│ 
│ on .terraform/modules/gke/modules/gcp/gke/main.tf line 83, in resource "google_container_cluster" "gke-cluster":
│ 83: identity_namespace = "${var.project}.svc.id.goog"
│ 
│ An argument named "identity_namespace" is not expected here.
╵
```