### PR TITLE
ensure backup bucket is in different project

### DIFF
--- a/modules/gcp/velero/main.tf
+++ b/modules/gcp/velero/main.tf
@@ -1,6 +1,6 @@
 # Create the velero backups bucket
 resource "google_storage_bucket" "backups" {
-  project      = var.project
+  project      = var.backup_project
   name = var.backups_bucket_name
   location = var.backups_bucket_location
 }
@@ -14,6 +14,7 @@ resource "google_service_account" "velero-service-account" {
 
 # Grant full control over objects, including listing, creating, viewing, and deleting storage objects in bucket.
 resource "google_storage_bucket_iam_member" "editor" {
+  project      = var.backup_project
   bucket = google_storage_bucket.backups.name
   role = "roles/storage.objectAdmin"
   member = "serviceAccount:${google_service_account.velero-service-account.email}"

--- a/modules/gcp/velero/variables.tf
+++ b/modules/gcp/velero/variables.tf
@@ -3,6 +3,11 @@ variable "project" {
   type        = string
 }
 
+variable "backup_project" {
+  description = "The name of the GCP Project where all backups will be stored."
+  type        = string
+}
+
 variable "service_account_name" {
   description = "The name of the custom service account. This parameter is limited to a maximum of 28 characters."
   type        = string


### PR DESCRIPTION
@eduartua @victortrac , I have created an extra variable `backup_project` which is the project where backups will be stored because backups cannot be within the same project as the apps due to security concerns i.e if app exists with storage.admin permissions in that projects then backups can be compromised