### PR TITLE
removing unrequired project argument in google_storage_bucket_iam_member

### DIFF
--- a/modules/gcp/velero/main.tf
+++ b/modules/gcp/velero/main.tf
@@ -14,7 +14,6 @@ resource "google_service_account" "velero-service-account" {
 
 # Grant full control over objects, including listing, creating, viewing, and deleting storage objects in bucket.
 resource "google_storage_bucket_iam_member" "editor" {
-  project      = var.backup_project
   bucket = google_storage_bucket.backups.name
   role = "roles/storage.objectAdmin"
   member = "serviceAccount:${google_service_account.velero-service-account.email}"


### PR DESCRIPTION
project not required as it will pick it from from bucket (parent object)