### PR TITLE
Add `compute.projects.get` to Velero custom role

### DIFF
--- a/modules/gcp/velero/main.tf
+++ b/modules/gcp/velero/main.tf
@@ -29,13 +29,13 @@ resource "google_project_iam_custom_role" "velero-server" {
     "compute.disks.get",
     "compute.disks.create",
     "compute.disks.createSnapshot",
+    "compute.projects.get",
     "compute.snapshots.get",
     "compute.snapshots.create",
     "compute.snapshots.useReadOnly",
     "compute.snapshots.delete",
     "compute.zones.get",
     "iam.serviceAccounts.signBlob",
-    "compute.projects.get",
   ]
 }
 

--- a/modules/gcp/velero/main.tf
+++ b/modules/gcp/velero/main.tf
@@ -34,7 +34,8 @@ resource "google_project_iam_custom_role" "velero-server" {
     "compute.snapshots.useReadOnly",
     "compute.snapshots.delete",
     "compute.zones.get",
-    "iam.serviceAccounts.signBlob"
+    "iam.serviceAccounts.signBlob",
+    "compute.projects.get",
   ]
 }
 


### PR DESCRIPTION
We have been experiencing partial Velero backups due to the error `error taking snapshot of volume: rpc error: code = Unknown desc = googleapi: Error 403: Required 'compute.projects.get' permission`.
This PR aims to resolve the issue by adding the missing permission. 