### PR TITLE
update azure domain zones module to have zone as key in dns a records

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Install tools
@@ -20,7 +20,7 @@ jobs:
         run: |
           bash -x ./scripts/github_actions-install_tools.sh
       - name: run pre-commit
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1
         env:
           # https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
           GITHUB_TOKEN: ${{ github.token }}

--- a/modules/azure/domain_zones/README.md
+++ b/modules/azure/domain_zones/README.md
@@ -54,7 +54,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
-| <a name="input_dns_a_records"></a> [dns\_a\_records](#input\_dns\_a\_records) | Map with dns A records to create and their configurations | <pre>map(object({<br/>    zone    = string<br/>    records = list(string)<br/>  }))</pre> | n/a | yes |
+| <a name="input_dns_a_records"></a> [dns\_a\_records](#input\_dns\_a\_records) | Map with dns A records to create and their configurations | <pre>map(object({<br/>    name    = string<br/>    records = list(string)<br/>  }))</pre> | n/a | yes |
 | <a name="input_dns_cname_records"></a> [dns\_cname\_records](#input\_dns\_cname\_records) | Map with dns CNAME records to create and their configurations | <pre>map(object({<br/>    zone   = string<br/>    record = string<br/>  }))</pre> | n/a | yes |
 | <a name="input_dns_domain_zones"></a> [dns\_domain\_zones](#input\_dns\_domain\_zones) | List of Top level domains to create | `list(string)` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Azure resource group name | `string` | n/a | yes |

--- a/modules/azure/domain_zones/main.tf
+++ b/modules/azure/domain_zones/main.tf
@@ -6,8 +6,8 @@ resource "azurerm_dns_zone" "domain_zone" {
 
 resource "azurerm_dns_a_record" "dns_a_records" {
   for_each            = var.dns_a_records
-  name                = each.key
-  zone_name           = each.value.zone
+  name                = each.value.name
+  zone_name           = each.key
   resource_group_name = var.resource_group_name
   ttl                 = 300
   records             = each.value.records

--- a/modules/azure/domain_zones/variables.tf
+++ b/modules/azure/domain_zones/variables.tf
@@ -11,7 +11,7 @@ variable "dns_domain_zones" {
 variable "dns_a_records" {
   description = "Map with dns A records to create and their configurations"
   type = map(object({
-    zone    = string
+    name    = string
     records = list(string)
   }))
 }

--- a/scripts/github_actions-install_tools.sh
+++ b/scripts/github_actions-install_tools.sh
@@ -49,7 +49,7 @@ retry_command "${retry}" 'bash' '-c' 'brew install terraform terraform-docs'
 KERNEL="$(uname | tr '[:upper:]' '[:lower:]')"
 ARCH="$(get_arch)"
 
-TFLINT_VERSION='0.45.0'
+TFLINT_VERSION='0.63.1'
 echo "Install tflint ${TFLINT_VERSION}"
 TFLINT_URL="https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_${KERNEL}_${ARCH}.zip"
 curl -sL "${TFLINT_URL}" -o /tmp/tflint.zip

--- a/scripts/github_actions-install_tools.sh
+++ b/scripts/github_actions-install_tools.sh
@@ -42,7 +42,7 @@ retry=5
 
 echo "Install from brew"
 ## TODO: install all tools via binary releases instead of brew to avoid brew's flakiness on github actions runners
-retry_command "${retry}" 'bash' '-c' 'brew install terraform terraform-docs"
+retry_command "${retry}" 'bash' '-c' 'brew install terraform terraform-docs'"
 
 
 KERNEL="$(uname | tr '[:upper:]' '[:lower:]')"

--- a/scripts/github_actions-install_tools.sh
+++ b/scripts/github_actions-install_tools.sh
@@ -42,7 +42,7 @@ retry=5
 
 echo "Install from brew"
 ## TODO: install all tools via binary releases instead of brew to avoid brew's flakiness on github actions runners
-retry_command "${retry}" 'bash' '-c' 'brew install terraform terraform-docs'"
+retry_command "${retry}" 'bash' '-c' 'brew install terraform terraform-docs'
 
 
 KERNEL="$(uname | tr '[:upper:]' '[:lower:]')"

--- a/scripts/github_actions-install_tools.sh
+++ b/scripts/github_actions-install_tools.sh
@@ -30,6 +30,7 @@ function get_arch() {
     armv6*) echo -n "armv6";;
     armv7*) echo -n "armv7";;
     aarch64) echo -n "arm64";;
+    arm64) echo -n "arm64";;
     x86) echo -n "386";;
     x86_64) echo -n "amd64";;
     i686) echo -n "386";;

--- a/scripts/github_actions-install_tools.sh
+++ b/scripts/github_actions-install_tools.sh
@@ -37,24 +37,21 @@ function get_arch() {
   esac
 }
 
-function get_os() {
-  local kernel_name
-  kernel_name="$(uname)"
-  case "${kernel_name}" in
-    Linux)
-      echo -n 'linux'
-      ;;
-    Darwin)
-      echo -n 'macos'
-      ;;
-    *)
-      echo "Sorry, ${kernel_name} is not supported." >&2
-      exit 1
-      ;;
-  esac
-}
 
 retry=5
 
 echo "Install from brew"
-retry_command "${retry}" 'bash' '-c' 'brew install terraform terraform-docs tflint'
+## TODO: install all tools via binary releases instead of brew to avoid brew's flakiness on github actions runners
+retry_command "${retry}" 'bash' '-c' 'brew install terraform terraform-docs"
+
+
+KERNEL="$(uname | tr '[:upper:]' '[:lower:]')"
+ARCH="$(get_arch)"
+
+TFLINT_VERSION='0.45.0'
+echo "Install tflint ${TFLINT_VERSION}"
+TFLINT_URL="https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_${KERNEL}_${ARCH}.zip"
+curl -sL "${TFLINT_URL}" -o /tmp/tflint.zip
+unzip -d /usr/local/bin/ /tmp/tflint.zip
+chmod +x /usr/local/bin/tflint
+rm -f /tmp/tflint.zip


### PR DESCRIPTION
The current format doesn't allow us to have multiple wildcard domains.
```
dns_a_records = {
  "*" = {
    records = ["20.x.x.x"]
    zone    = "example.com"
  }
}
```
This PR enables us to have
```
dns_a_records = {
  "example.com" = {
    records = ["20.x.x.x"]
    name    = "*"
  }
  "example.org" = {
    records = ["25.x.x.x"]
    name    = "*"
  }
}
```