### PR TITLE
allow unique dns records for azure domain zones module

### DIFF
--- a/modules/azure/domain_zones/README.md
+++ b/modules/azure/domain_zones/README.md
@@ -54,8 +54,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
-| <a name="input_dns_a_records"></a> [dns\_a\_records](#input\_dns\_a\_records) | Map with dns A records to create and their configurations | <pre>map(object({<br/>    name    = string<br/>    records = list(string)<br/>  }))</pre> | n/a | yes |
-| <a name="input_dns_cname_records"></a> [dns\_cname\_records](#input\_dns\_cname\_records) | Map with dns CNAME records to create and their configurations | <pre>map(object({<br/>    zone   = string<br/>    record = string<br/>  }))</pre> | n/a | yes |
+| <a name="input_dns_a_records"></a> [dns\_a\_records](#input\_dns\_a\_records) | Map with dns A records to create and their configurations | <pre>map(object({<br/>    records = list(string)<br/>  }))</pre> | n/a | yes |
+| <a name="input_dns_cname_records"></a> [dns\_cname\_records](#input\_dns\_cname\_records) | Map with dns CNAME records to create and their configurations | <pre>map(object({<br/>    record = string<br/>  }))</pre> | n/a | yes |
 | <a name="input_dns_domain_zones"></a> [dns\_domain\_zones](#input\_dns\_domain\_zones) | List of Top level domains to create | `list(string)` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Azure resource group name | `string` | n/a | yes |
 

--- a/modules/azure/domain_zones/main.tf
+++ b/modules/azure/domain_zones/main.tf
@@ -6,8 +6,8 @@ resource "azurerm_dns_zone" "domain_zone" {
 
 resource "azurerm_dns_a_record" "dns_a_records" {
   for_each            = var.dns_a_records
-  name                = each.value.name
-  zone_name           = each.key
+  name                = split(".", each.key)[0]
+  zone_name           = join(slice(split(".", each.key), 1, length(split(".", each.key))), ".")
   resource_group_name = var.resource_group_name
   ttl                 = 300
   records             = each.value.records
@@ -18,8 +18,8 @@ resource "azurerm_dns_a_record" "dns_a_records" {
 
 resource "azurerm_dns_cname_record" "dns_cname_records" {
   for_each            = var.dns_cname_records
-  name                = each.key
-  zone_name           = each.value.zone
+  name                = split(".", each.key)[0]
+  zone_name           = join(slice(split(".", each.key), 1, length(split(".", each.key))), ".")
   resource_group_name = var.resource_group_name
   ttl                 = 300
   record              = "${each.key}.${each.value.record}"

--- a/modules/azure/domain_zones/main.tf
+++ b/modules/azure/domain_zones/main.tf
@@ -22,7 +22,7 @@ resource "azurerm_dns_cname_record" "dns_cname_records" {
   zone_name           = join(slice(split(".", each.key), 1, length(split(".", each.key))), ".")
   resource_group_name = var.resource_group_name
   ttl                 = 300
-  record              = "${each.key}.${each.value.record}"
+  record              = each.value.record
   depends_on = [
     azurerm_dns_zone.domain_zone
   ]

--- a/modules/azure/domain_zones/variables.tf
+++ b/modules/azure/domain_zones/variables.tf
@@ -11,7 +11,6 @@ variable "dns_domain_zones" {
 variable "dns_a_records" {
   description = "Map with dns A records to create and their configurations"
   type = map(object({
-    name    = string
     records = list(string)
   }))
 }
@@ -19,7 +18,6 @@ variable "dns_a_records" {
 variable "dns_cname_records" {
   description = "Map with dns CNAME records to create and their configurations"
   type = map(object({
-    zone   = string
     record = string
   }))
 }


### PR DESCRIPTION
- This allows for
```
dns_a_records = {
  "*.az-dev.over-haul.com" = {
    records = ["20.x.x.x"]
  }
  "test.az-dev.over-haul.com" = {
    records = ["30.x.x.x"]
  }
```

```
dns_cname_records = {
  "test.az-dev.over-haul.com" = {
    record = "x.argotunnel.com"
  }
```